### PR TITLE
Improve CodeScanning top 10 report to use better severities

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -64703,6 +64703,7 @@ class CodeScanning extends Printable {
     attributes = [
         "Vulnerability",
         "Severity",
+        "Weakness",
         "Tool",
         "Vulnerable file",
         "Link",
@@ -64715,10 +64716,25 @@ class CodeScanning extends Printable {
         this.metrics = AlertsMetrics(alerts, frequency, "fixed_at", "fixed", true, "commitDate", "created_at");
         return this.metrics;
     }
+    //Extracts CWE-### from CodeScanningAlert.rule.tags[] from any format like  "external/cwe/cwe-247" or "CWE-352: Cross-Site Request Forgery (CSRF)"
+    cweFromTags(rule) {
+        const cwe = rule.rule?.tags
+            .map((tag) => {
+            const cwe = tag.match(/cwe-(\d+)/i);
+            if (cwe) {
+                return `CWE-${cwe[1]}`;
+            }
+            return "";
+        })
+            .filter((cwe) => cwe !== "")
+            .join(", ");
+        return cwe;
+    }
     summaryTop10() {
         return this.metrics.top10.map((a) => [
             a.rule?.name || "",
             a.rule?.security_severity_level || a.rule?.severity || "",
+            this.cweFromTags(a),
             a.tool?.name || "",
             a.most_recent_instance?.location.path || "",
             a.html_url,

--- a/dist/index.js
+++ b/dist/index.js
@@ -64486,20 +64486,20 @@ function compareAlertSeverity(a, b) {
     const weight = {
         critical: 7,
         high: 6,
-        medium: 5,
-        low: 4,
+        error: 5,
+        medium: 4,
         warning: 3,
-        note: 2,
-        error: 1,
+        low: 2,
+        note: 1,
         none: 0,
     };
     const severity1 = getAlertSeverity(a);
     const severity2 = getAlertSeverity(b);
-    if (weight[severity1] < weight[severity2]) {
-        return 1;
-    }
-    else if (weight[severity1] > weight[severity2]) {
+    if (weight[severity1] > weight[severity2]) {
         return -1;
+    }
+    else if (weight[severity1] < weight[severity2]) {
+        return 1;
     }
     return 0;
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -64470,8 +64470,19 @@ const FilterBetweenDates = (stringDate, minDate, maxDate) => {
     const date = Date.parse(stringDate);
     return date >= minDate.getTime() && date < maxDate.getTime();
 };
+function getAlertSeverity(alert) {
+    if (isDependancyAlert(alert)) {
+        return alert.security_advisory.severity.toLowerCase();
+    }
+    else if (isCodeScanningAlert(alert)) {
+        const codeScanningAlert = alert;
+        return codeScanningAlert.rule?.security_severity_level
+            ? codeScanningAlert.rule?.security_severity_level.toLowerCase()
+            : codeScanningAlert.rule?.severity.toLowerCase() || "none";
+    }
+    return "none";
+}
 function compareAlertSeverity(a, b) {
-    //critical, high, medium, low, warning, note, error
     const weight = {
         critical: 7,
         high: 6,
@@ -64482,22 +64493,15 @@ function compareAlertSeverity(a, b) {
         error: 1,
         none: 0,
     };
-    let comparison = 0;
-    let severity1 = "none";
-    let severity2 = "none";
-    severity1 = isDependancyAlert(a)
-        ? a.security_advisory.severity.toLowerCase()
-        : a.rule?.severity.toLowerCase();
-    severity2 = isDependancyAlert(b)
-        ? b.security_advisory.severity.toLowerCase()
-        : b.rule?.severity.toLowerCase();
+    const severity1 = getAlertSeverity(a);
+    const severity2 = getAlertSeverity(b);
     if (weight[severity1] < weight[severity2]) {
-        comparison = 1;
+        return 1;
     }
     else if (weight[severity1] > weight[severity2]) {
-        comparison = -1;
+        return -1;
     }
-    return comparison;
+    return 0;
 }
 function isDependancyAlert(alert) {
     return "security_advisory" in alert;

--- a/dist/index.js
+++ b/dist/index.js
@@ -64718,7 +64718,7 @@ class CodeScanning extends Printable {
     summaryTop10() {
         return this.metrics.top10.map((a) => [
             a.rule?.name || "",
-            a.rule?.severity || "",
+            a.rule?.security_severity_level || a.rule?.severity || "",
             a.tool?.name || "",
             a.most_recent_instance?.location.path || "",
             a.html_url,

--- a/dist/index.js
+++ b/dist/index.js
@@ -64736,7 +64736,9 @@ class CodeScanning extends Printable {
             a.rule?.security_severity_level || a.rule?.severity || "",
             this.cweFromTags(a),
             a.tool?.name || "",
-            a.most_recent_instance?.location.path || "",
+            a.most_recent_instance?.location?.path
+                ? `${a.most_recent_instance.location.path}#L${a.most_recent_instance.location.start_line}`
+                : "",
             a.html_url,
         ]);
     }

--- a/src/context/CodeScanning.ts
+++ b/src/context/CodeScanning.ts
@@ -16,6 +16,7 @@ export class CodeScanning extends Printable implements Feature {
   attributes: string[] = [
     "Vulnerability",
     "Severity",
+    "Weakness",
     "Tool",
     "Vulnerable file",
     "Link",
@@ -46,10 +47,26 @@ export class CodeScanning extends Printable implements Feature {
     return this.metrics;
   }
 
+  //Extracts CWE-### from CodeScanningAlert.rule.tags[] from any format like  "external/cwe/cwe-247" or "CWE-352: Cross-Site Request Forgery (CSRF)"
+  cweFromTags(rule: CodeScanningAlert): string {
+    const cwe = rule.rule?.tags
+      .map((tag) => {
+        const cwe = tag.match(/cwe-(\d+)/i);
+        if (cwe) {
+          return `CWE-${cwe[1]}`;
+        }
+        return "";
+      })
+      .filter((cwe) => cwe !== "")
+      .join(", ");
+    return cwe;
+  }
+
   summaryTop10(): string[][] {
     return this.metrics.top10.map((a: CodeScanningAlert) => [
       a.rule?.name || "",
       a.rule?.security_severity_level || a.rule?.severity || "",
+      this.cweFromTags(a),
       a.tool?.name || "",
       a.most_recent_instance?.location.path || "",
       a.html_url,

--- a/src/context/CodeScanning.ts
+++ b/src/context/CodeScanning.ts
@@ -68,7 +68,9 @@ export class CodeScanning extends Printable implements Feature {
       a.rule?.security_severity_level || a.rule?.severity || "",
       this.cweFromTags(a),
       a.tool?.name || "",
-      a.most_recent_instance?.location.path || "",
+      a.most_recent_instance?.location?.path
+        ? `${a.most_recent_instance.location.path}#L${a.most_recent_instance.location.start_line}`
+        : "",
       a.html_url,
     ]);
   }

--- a/src/context/CodeScanning.ts
+++ b/src/context/CodeScanning.ts
@@ -49,7 +49,7 @@ export class CodeScanning extends Printable implements Feature {
   summaryTop10(): string[][] {
     return this.metrics.top10.map((a: CodeScanningAlert) => [
       a.rule?.name || "",
-      a.rule?.severity || "",
+      a.rule?.security_severity_level || a.rule?.severity || "",
       a.tool?.name || "",
       a.most_recent_instance?.location.path || "",
       a.html_url,

--- a/src/types/common/main.d.ts
+++ b/src/types/common/main.d.ts
@@ -187,6 +187,7 @@ export interface Rule {
   description: string;
   name: string;
   tags: string[];
+  security_severity_level: string;
 }
 
 export interface Tool {

--- a/src/utils/AlertMetrics.ts
+++ b/src/utils/AlertMetrics.ts
@@ -172,21 +172,21 @@ function compareAlertSeverity(a: Alert, b: Alert) {
   const weight: { [key: string]: number } = {
     critical: 7,
     high: 6,
-    medium: 5,
-    low: 4,
+    error: 5,
+    medium: 4,
     warning: 3,
-    note: 2,
-    error: 1,
+    low: 2,
+    note: 1,
     none: 0,
   };
 
   const severity1 = getAlertSeverity(a);
   const severity2 = getAlertSeverity(b);
 
-  if (weight[severity1] < weight[severity2]) {
-    return 1;
-  } else if (weight[severity1] > weight[severity2]) {
+  if (weight[severity1] > weight[severity2]) {
     return -1;
+  } else if (weight[severity1] < weight[severity2]) {
+    return 1;
   }
   return 0;
 }


### PR DESCRIPTION
This pull request includes changes to improve the handling and comparison of alert severities in the `CodeScanning` feature. The most important changes include modifying the severity level handling in the `summaryTop10` method and refactoring the severity comparison logic in `AlertMetrics`.

Enhancements to `CodeScanning` class:

* Added `Weakness` to the attributes list in the `CodeScanning` class to include CWE information in the output.
* Implemented the `cweFromTags` method to extract CWE information from alert tags, improving the clarity and detail of the alert summaries.
* Updated the `summaryTop10` method to include CWE information and improve the formatting of file paths in the output.

Improvements to `AlertMetrics` utility:

* Added the `getAlertSeverity` function to centralize and simplify the logic for determining the severity of different types of alerts.
* Refactored the `compareAlertSeverity` function to use the new `getAlertSeverity` function, improving code readability and maintainability.

Before:
- prioritizing note/warning severity items
![image](https://github.com/user-attachments/assets/9b76bbb9-84f9-4c75-ac34-509f3b06fd1e)


After:
- uses security severity and prioritizes based on highest severity order
- Adds CWE information
- Adds start line to the location

![image](https://github.com/user-attachments/assets/5aa904b0-eb00-49ca-9ca4-84b195da118a)

